### PR TITLE
Add support for displaying LWC entities in notebook platforms (#7)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LightweightCharts"
 uuid = "d6998af1-87ca-4e7f-83d4-864c79a249fa"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 Serde = "db9b398d-9517-45f8-9a95-92af99003e0e"

--- a/src/LightweightCharts.jl
+++ b/src/LightweightCharts.jl
@@ -110,6 +110,10 @@ function Base.show(io::IO, h::LWCChart)
     return println(io, "LightweightCharts.LWCChart($(h.label_name))")
 end
 
+function Base.show(io::IO, m::MIME"text/html", h::LWCChart)
+    return write(io, string(h))
+end
+
 include("charts.jl")
 using .LWCCharts
 
@@ -143,6 +147,10 @@ end
 
 function Base.show(io::IO, h::LWCPanel)
     return println(io, "LightweightCharts.LWCPanel($(h.name))")
+end
+
+function Base.show(io::IO, m::MIME"text/html", h::LWCPanel)
+    return write(io, string(h))
 end
 
 """
@@ -219,6 +227,10 @@ end
 
 function Base.show(io::IO, h::LWCLayout)
     return println(io, "LightweightCharts.LWCLayout($(h.name))")
+end
+
+function Base.show(io::IO, m::MIME"text/html", h::LWCLayout)
+    return write(io, string(h))
 end
 
 function update_not_set_coords!(panels::Tuple{Vararg{LWCPanel}})


### PR DESCRIPTION
### Pull request checklist

- [x] Did you bump the project version?
- [ ] Did you add a description to the Pull Request?
- [ ] Did you add new tests?
- [ ] Did you add reviewers?

___
I overloaded the show function with a MIME specification, thus adding support for displaying LWC entities in notebooks.

<details>
  <summary>Jupyter example</summary>
  
<img width="1233" alt="jupyter" src="https://github.com/bhftbootcamp/LightweightCharts.jl/assets/66777881/54a90c27-0072-43d4-b383-a98f777d03de">
  
</details>

<details>
  <summary>Pluto example</summary>
  
<img width="723" alt="pluto" src="https://github.com/bhftbootcamp/LightweightCharts.jl/assets/66777881/763a0aa6-a852-4c0b-80cd-5942c852c52b">
  
</details>