### PR TITLE
Update crosshair_highlight_bar.jl - fix typo in docstring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LightweightCharts"
 uuid = "d6998af1-87ca-4e7f-83d4-864c79a249fa"
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/plugins/crosshair_highlight_bar.jl
+++ b/src/plugins/crosshair_highlight_bar.jl
@@ -5,7 +5,7 @@ struct CrosshairHighlightBarSettings <: AbstractPluginSettings
 end
 
 """
-    lwc_vert_line(; kw...) -> LWCPlugin
+    lwc_crosshair_highlight_bar(; kw...) -> LWCPlugin
 
 Adds additional highlighting to the cursor crosshairs.
 


### PR DESCRIPTION
The docstring said lwc_vert_line instead of lwc_crosshair_highlight_bar.

### Pull request checklist

- [ ] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [ ] Did you add new tests?
- [ ] Did you add reviewers?

> It's just a small documentation fix.