### PR TITLE
Add Useful Links section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,9 @@ lwc_show(chart)
 ## Contributing
 
 Contributions to LightweightCharts are welcome! If you encounter a bug, have a feature request, or would like to contribute code, please open an issue or a pull request on GitHub.
+
+## Useful Links
+
+- [tradingview/lightweight-charts](https://github.com/tradingview/lightweight-charts) – Performant financial charts built with HTML5 canvas
+- [Lightweight Charts™ Documentation](https://www.tradingview.com/lightweight-charts/) – Official TradingView Lightweight Charts documentation
+- [LightweightCharts.jl Documentation](https://bhftbootcamp.github.io/LightweightCharts.jl/stable/) – Stable documentation for LightweightCharts.jl


### PR DESCRIPTION
## Summary

- Add a **Useful Links** section to the bottom of the README with references to the upstream TradingView Lightweight Charts library, its official documentation, and the Julia package documentation.

## Details

The new section includes:
- [tradingview/lightweight-charts](https://github.com/tradingview/lightweight-charts) – the upstream JS library
- [Lightweight Charts™ Documentation](https://www.tradingview.com/lightweight-charts/) – official TradingView docs
- [LightweightCharts.jl Documentation](https://bhftbootcamp.github.io/LightweightCharts.jl/stable/) – stable Julia package docs

Uses en dash (–) as separator, following bhftbootcamp formatting conventions.